### PR TITLE
Add flags for markdown and disabling webpage preview

### DIFF
--- a/lib/telegram_bot/out_message.rb
+++ b/lib/telegram_bot/out_message.rb
@@ -5,6 +5,7 @@ module TelegramBot
     attribute :text, String
     attribute :reply_to, Message
     attribute :parse_mode, String
+    attribute :disable_web_page_preview, Boolean
 
     def send_with(bot)
       bot.send_message(self)
@@ -15,20 +16,16 @@ module TelegramBot
     end
 
     def to_h
-      if reply_to.nil? then
-        {
+      message = {
           text: text,
-          chat_id: chat.id,
-          parse_mode: parse_mode
-        }
-      else
-        {
-          text: text,
-          chat_id: chat.id,
-          reply_to_message_id: reply_to.id,
-          parse_mode: parse_mode
-        }
-      end
+          chat_id: chat.id
+      }
+
+      message[:reply_to_message_id] = reply_to.id unless reply_to.nil?
+      message[:parse_mode] = parse_mode unless parse_mode.nil?
+      message[:disable_web_page_preview] = disable_web_page_preview unless disable_web_page_preview.nil?
+
+      message
     end
   end
 end

--- a/lib/telegram_bot/out_message.rb
+++ b/lib/telegram_bot/out_message.rb
@@ -4,6 +4,7 @@ module TelegramBot
     attribute :chat, Channel
     attribute :text, String
     attribute :reply_to, Message
+    attribute :parse_mode, String
 
     def send_with(bot)
       bot.send_message(self)
@@ -17,13 +18,15 @@ module TelegramBot
       if reply_to.nil? then
         {
           text: text,
-          chat_id: chat.id
+          chat_id: chat.id,
+          parse_mode: parse_mode
         }
       else
         {
           text: text,
           chat_id: chat.id,
-          reply_to_message_id: reply_to.id
+          reply_to_message_id: reply_to.id,
+          parse_mode: parse_mode
         }
       end
     end


### PR DESCRIPTION
This adds the flags `parse_mode` and `disable_web_page_preview`.
Setting  `reply.parse_mode = "Markdown"` enables some formatting in the message (see https://core.telegram.org/bots/api#using-markdown).
Setting `reply.disable_web_page_preview = true` prevents the client from loading previews for any URLs in the response.

Resolves #21