### PR TITLE
Discard "nil" message "received" from the server.

### DIFF
--- a/lib/telegram_bot/bot.rb
+++ b/lib/telegram_bot/bot.rb
@@ -31,7 +31,7 @@ module TelegramBot
       logger.info "starting get_updates loop"
       loop do
         messages = get_last_messages(opts)
-        messages.each do |message|
+        messages.compact.each do |message|
           logger.info "message from @#{message.chat.friendly_name}: #{message.text.inspect}"
           yield message
         end


### PR DESCRIPTION
Now Telegram server can return special messages which are "nil"
after being processed by "get_last_message".

Though this patch is good, the better way is still to fix in "get_last_message".