### PR TITLE
Added guard check against some cases where the telegram-side of the bot causes crashes

### DIFF
--- a/lib/telegram_bot/bot.rb
+++ b/lib/telegram_bot/bot.rb
@@ -32,6 +32,7 @@ module TelegramBot
       loop do
         messages = get_last_messages(opts)
         messages.compact.each do |message|
+          next unless message
           logger.info "message from @#{message.chat.friendly_name}: #{message.text.inspect}"
           yield message
         end


### PR DESCRIPTION
Sometimes, it happened to me that the telegram-side of the bot gets in a state where the loop in bot.rb at line 33 continuously gets a nil message. This is hard to debug: 'til now, I always had to delete and recreate the bot (!).
This simple addition is a guard check that makes the code more robust.

BTW, when it happens the error says something like that:
```
I, [2016-06-22T09:30:54.012526 #5879]  INFO -- : starting get_updates loop
/var/lib/gems/2.1.0/gems/telegram_bot-0.0.5/lib/telegram_bot/bot.rb:34:in `block (2 levels) in get_updates': undefined method `chat' for nil:NilClass (NoMethodError)
	from /var/lib/gems/2.1.0/gems/telegram_bot-0.0.5/lib/telegram_bot/bot.rb:33:in `each'
	from /var/lib/gems/2.1.0/gems/telegram_bot-0.0.5/lib/telegram_bot/bot.rb:33:in `block in get_updates'
	from /var/lib/gems/2.1.0/gems/telegram_bot-0.0.5/lib/telegram_bot/bot.rb:31:in `loop'
	from /var/lib/gems/2.1.0/gems/telegram_bot-0.0.5/lib/telegram_bot/bot.rb:31:in `get_updates'
```