### PR TITLE
Enhancement/integrate minitest

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,10 @@
 require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new(:spec) do |t|
+  t.libs    = %w(lib spec)
+  t.pattern = 'spec/**/*_spec.rb'
+end
+
+task :default => :spec
 

--- a/spec/minitest_helper.rb
+++ b/spec/minitest_helper.rb
@@ -1,0 +1,2 @@
+require 'telegram_bot'
+require 'minitest/autorun'

--- a/spec/telegram_bot_spec.rb
+++ b/spec/telegram_bot_spec.rb
@@ -1,0 +1,4 @@
+require 'minitest_helper'
+
+describe TelegramBot do
+end

--- a/telegram_bot.gemspec
+++ b/telegram_bot.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "virtus", ">= 1.0.0"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "minitest", "~> 5.10"
 end


### PR DESCRIPTION
This is the initial setup to start using minitest/spec for the project.
The pull request includes:
* Changes on Rakefile to define a spec task for rake and set it as the default task to run.
* Changes on the gemspec to add minitest as a development dependency.
* minitest_helper.rb file to contain spec setup & config.
* A spec stub to make sure the setup works by running $ rake spec

The first specs will be implemented in the upcoming pull requests.