### PR TITLE
Fix link to Contributor Covenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ bot.send_message(reply)
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/eljojo/telegram_bot. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/eljojo/telegram_bot. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](https://www.contributor-covenant.org/) code of conduct.
 
 
 ## License


### PR DESCRIPTION
The link to Contributor Covenant was a relative link that broke when clicked on from the README. This change makes that link an absolute link.