### PR TITLE
response error load missing

### DIFF
--- a/lib/telegram_bot.rb
+++ b/lib/telegram_bot.rb
@@ -15,6 +15,7 @@ require "telegram_bot/force_replay"
 require "telegram_bot/out_message"
 require "telegram_bot/update"
 require "telegram_bot/api_response"
+require "telegram_bot/response_error"
 require "telegram_bot/bot"
 
 


### PR DESCRIPTION
If telegram API replies with an error an exception is launched because the ResponseError file is never included.