### PR TITLE
Include location data sent to Bot

### DIFF
--- a/lib/telegram_bot.rb
+++ b/lib/telegram_bot.rb
@@ -18,6 +18,7 @@ require "telegram_bot/update"
 require "telegram_bot/api_response"
 require "telegram_bot/bot"
 require "telegram_bot/client"
+require "telegram_bot/location"
 
 
 module TelegramBot

--- a/lib/telegram_bot/location.rb
+++ b/lib/telegram_bot/location.rb
@@ -1,0 +1,11 @@
+module TelegramBot
+  class Location
+    include Virtus.model
+    attribute :latitude, Float
+    attribute :longitude, Float
+
+    def full
+      [latitude, longitude]
+    end
+  end
+end

--- a/lib/telegram_bot/message.rb
+++ b/lib/telegram_bot/message.rb
@@ -10,6 +10,7 @@ module TelegramBot
     attribute :date, DateTime
     attribute :chat, Channel
     attribute :reply_to_message, Message
+    attribute :location, Location
 
     def reply(&block)
       reply = OutMessage.new(chat: chat)


### PR DESCRIPTION
This PR includes locations sharing from the user to the bot.

The workflow is when clicking 'Send my current location' a new message
is sent to the bot with latitude and longitude accessed via
`my_message.location`. To get the coordinates in an array, this can
be accessed via `my_message.location.full`. Original api discussion
[here](https://core.telegram.org/bots/api#location).

This PR does *not* implement sharing of live locations, which are
[implemented in a wholly different manner](https://telegram.org/blog/live-locations) by nesting
the information within `edited_message`. To include live locations we
would also need to bring in the `edited_message` functionality. I will
be approaching this with my next PR.